### PR TITLE
Fixes to the labelling functions

### DIFF
--- a/plugins/custom_grid_label/customgridlabel/gridlabelfunctions.py
+++ b/plugins/custom_grid_label/customgridlabel/gridlabelfunctions.py
@@ -9,19 +9,28 @@ from qgis.PyQt.QtCore import *
 
 @qgsfunction(args='auto', group='sagta')
 def get_grid_interval(map_scale, feature, parent):
+    """Calculates the grid interval.
+    :param map_scale: The map scale e.g. 50 000
+    :type map_scale: float
+    
+    :return: grid interval
+    :rtype: float
+    """
+    
     current_scale = float(map_scale)
-    if map_scale >= 150000:
+    if map_scale >= 140000:  # 150k
         result = 0.066666666668
-    elif 99999 <= map_scale < 150000:
+    elif 98000 <= map_scale < 110000:  # 100k
         result = 0.033333333334
-    elif 49999 <= map_scale < 99999:
+    elif 48000 <= map_scale < 52000:  # 50k
         result = 0.016666666667
-    elif 24999 <= map_scale < 49999:
-        result = 0.0083333333335
+    elif 23000 <= map_scale < 27000:  # 25k
+        result = 0.016666666667
     else:
         result = 0.00416666666675
+    
     return result
-        
+
     
 @qgsfunction(args='auto', group='sagta')
 def get_grid_label(
@@ -31,19 +40,42 @@ def get_grid_label(
         current_grid_value,
         use_letters,
         reversed,
+        map_scale,
+        axis,
         feature,
         parent,
         context
 ):
+    """Determines the grid label for the provider grid position.
+    :param map_width: Width of the layout
+    :type map_width: float
+    
+    :param extent_min: Minimum coordinate value for the extent
+    :type extent_min: float
+    
+    :param interval_width: Width of each grid
+    :type interval_width: float
+    
+    :param current_grid_value: Index of the current grid to be labelled
+    :type current_grid_value: int
+    
+    :param use_letters: If set to True, alphabetic chars will be used
+    :type use_letters: boolean
+    
+    :param reversed: Reverse labelling order
+    :type reversed: boolean
+    
+    :param map_scale: Scale of the current map (e.g. 50 000)
+    :type map_scale: float
+    
+    :param axis: The used by the layout (this will be x for the y-axis, y for the x-axis)
+    :type axis: string
+    
+    :return: Returns the label. Alphabetic chars for y-axis, numeric for x-axis
+    :rtype: str/int
     """
-    Calculates the current X label.
-    <h2>Example usage:</h2>
-    <ul>
-      <li>my_sum(5, 8) -> 13</li>
-      <li>my_sum("field1", "field2") -> 42</li>
-    </ul>
-    """
-    num_intervals = math.ceil(map_width / interval_width)  # Number of grid blocks
+    
+    num_intervals = get_num_intervals(axis, map_scale)  # Number of grid intervals
     current_position = current_grid_value - extent_min  # Label position
     
     for i in range(num_intervals):  # Loops through each of the grids
@@ -63,7 +95,46 @@ def get_grid_label(
         result = 'error'
     
     return result
+
+
+def get_num_intervals(axis, map_scale):
+    """Determines the grid label for the provider grid position.
+    :param axis: Axis returned by QGIS
+    :type axis: str
     
+    :param map_scale: Scale of the current map
+    :type map_scale: float
+    
+    :return: Returns the number of intervals
+    :rtype: int
+    """
+    
+    num_intervals = -1
+    if 23000 <= map_scale < 27000:  # 25k
+        if axis == 'x':
+            num_intervals = 3
+            #num_intervals = 5
+        else:
+            num_intervals = 5
+            #num_intervals = 10
+    elif 48000 <= map_scale < 52000:  # 50k
+        if axis == 'x':
+            num_intervals = 5
+        else:
+            num_intervals = 10
+    elif 98000 <= map_scale < 110000:  # 100k
+        if axis == 'x':
+            num_intervals = 5
+        else:
+            num_intervals = 10
+    elif map_scale >= 140000:  # 150k
+        if axis == 'x':
+            num_intervals = 4
+        else:
+            num_intervals = 8
+    
+    return num_intervals
+
     
 def get_choices_label(
         current_item: int,
@@ -72,16 +143,40 @@ def get_choices_label(
         choices: typing.Optional[typing.Iterable] = None,
         offset: typing.Optional[int] = 1,
 ) -> str:
+    """Gets the label for the evaluated grid index.
+    :current_item: Index of current grid
+    :type current_item: int
+    
+    :param total_items: Total number of grids for the x- or y-axis
+    :type total_items: int
+    
+    :param reverse_order: True if the labelling order should be reversed
+    :type reverse_order: boolean
+    
+    :param choices: If the user provides a list of choices
+    :type choices: array
+    
+    :param offset: Offset set by the user
+    :type offset: int
+    
+    :return: Returns the label. Alphabetic chars for y-axis, numeric for x-axis
+    :rtype: str/int
+    """
+    
     output_values = None
+    
     if choices is None:  # x-axis, therefore integer values
         # Increments with one to be sure to include the last grid block case
         possible_outputs = range(total_items + 1)
         output_values = list(possible_outputs)[:total_items + 1]
+        
+        index = current_item + offset
+        
     else:  # y-axis, therefore alphabetical characters
         possible_outputs = choices
         output_values = list(possible_outputs)[:total_items]
+        
+        list_len = len(output_values)
+        index = total_items - current_item - offset  # Reverses the order
     
-    if reverse_order:  # This is only done for the y-axis - alphabetical characters
-        output_values.reverse()
-    
-    return output_values[current_item + offset]
+    return output_values[index]


### PR DESCRIPTION
Fix for the y-axis where the first label will access a non-existing list element
Updated the get grid interval method to make use of other scale values when performing if statements
The grid label method 25k result will now be 0.01666666667, to adhere with 1 minute per grid
Added the get num intervals method
Get choices label will now make use of a reversed index value as appossed to reversing the list completely for the y-axis (this solved an issue with the y-axis).

![image](https://user-images.githubusercontent.com/79740955/162693448-9ec9bd56-5410-4a72-bbef-b5cb7a77272d.png)
